### PR TITLE
added windows compatibility

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,16 @@
 #![allow(unused)]
 use std::{path::PathBuf, process::Command};
 
+#[cfg(target_os = "windows")]
+static PATH_FINDER_COMMAND: &str = "where";
+#[cfg(target_os = "linux")]
+static PATH_FINDER_COMMAND: &str = "which";
+
+#[cfg(target_os = "windows")]
+static GFORTRAN_NAME      : &str = "gfortran";
+#[cfg(target_os = "linux")]
+static GFORTRAN_NAME      : &str = "gfortran-13";
+
 macro_rules! p {
     ($($tokens: tt)*) => {
         println!("cargo:warning={}", format!($($tokens)*))
@@ -11,13 +21,13 @@ macro_rules! p {
 pub fn main() {
     if std::env::var("DOCS_RS").is_ok() {
     } else {
-        _ = get_fortran_compiler().expect("gfortran-13 not installed!");
+        _ = get_fortran_compiler().expect(&format!("{} not installed!",GFORTRAN_NAME));
         let out_path: PathBuf = std::env::var("OUT_DIR").unwrap().into();
         let lib_name = "amos";
         let mut lib_path = out_path.clone();
         lib_path.push(format!("lib{lib_name}.a"));
 
-        Command::new("gfortran-13")
+        Command::new(GFORTRAN_NAME)
             .arg("-shared")
             .arg("amos/amos_iso_c_fortran_wrapper.f90")
             .arg("amos/machine.for")
@@ -39,8 +49,8 @@ fn main() {}
 fn get_fortran_compiler() -> Option<String> {
     Some(
         String::from_utf8_lossy(
-            &Command::new("which")
-                .arg("gfortran-13")
+            &Command::new(&PATH_FINDER_COMMAND)
+                .arg(&GFORTRAN_NAME)
                 .output()
                 .ok()?
                 .stdout,
@@ -48,3 +58,4 @@ fn get_fortran_compiler() -> Option<String> {
         .to_string(),
     )
 }
+


### PR DESCRIPTION
## Adding Windows compatibility

### Why
In Windows, the command program to find the path of a given program is `where`, not `which`.

Also, when installing the `gfortran` the name of the program is `gfortran` instead of `gfortran-13`

 ### How
In `/build.rs` I added compile target platform-specific variable 

- `static PATH_FINDER_COMMAND: &str `, and 
-  `static GFORTRAN_NAME : &str`

which is set to platform-specific str, 

Then I changed the `get_fortran_compiler` to replace the hard-coded `str` with those variables.

And at `main`, I replaced the command for compiling Fortran code with the platform-specific name

### Result 
Can build on Windows machine now, well it works on my machine
```
PS ..\complex-bessel-rs> cargo  build 
   Compiling num-traits v0.2.16
   Compiling num-integer v0.1.45
   Compiling num-complex v0.4.4
   Compiling num-bigint v0.4.4
   Compiling num-iter v0.1.43
   Compiling num-rational v0.4.1
   Compiling num v0.4.1
   Compiling complex-bessel-rs v0.0.5 (..\complex-bessel-rs)
    Finished dev [unoptimized + debuginfo] target(s) in 3.47s
```