### PR TITLE
Correct error checking in bessel_i

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -25,7 +25,6 @@ pub fn main() {
         if !path.to_string_lossy().is_empty() {
             println!("cargo:rustc-link-search={}", path.display());
         }
-        
     }
 
     println!("cargo:rustc-link-lib=gfortran");

--- a/src/bessel_i.rs
+++ b/src/bessel_i.rs
@@ -44,12 +44,13 @@ unsafe fn _bessel_i(order: f64, z: Complex64) -> Result<Complex64, i32> {
 
         answer += 2.0 / std::f64::consts::PI * s * answerk;
 
-        if ierr != 0 {
-            return Err(ierr);
-        }
         if ierrk != 0 {
             return Err(ierrk);
         }
+    }
+
+    if ierr != 0 {
+        return Err(ierr);
     }
 
     Ok(answer)


### PR DESCRIPTION
I was having an issue with bessel_i not returning the correct error. I looked into the code and found that, in `_bessel_i`, if `order >= 0.0` the code `ierr` is never checked. 

This PR moves the check of `ierr` out of the `if order < 0.0` section. This matches the behavior of `_bessel_i` to that of `_bessel_j` and fixes the issue.